### PR TITLE
Update details.js

### DIFF
--- a/src/spaces/details.js
+++ b/src/spaces/details.js
@@ -73,7 +73,7 @@ class DetailElement extends HTMLElement {
     this.shadowRoot.querySelector(".space-useragent").value = val.useragent ?? "";
     this.shadowRoot.querySelector(".space-notifications").checked = val.notifications ?? true;
     this.shadowRoot.querySelector(".space-startup").checked = val.startup ?? false;
-    this.shadowRoot.querySelector(".internal-links").checked = val.internalLinks?.join("\n") ?? "";
+    this.shadowRoot.querySelector(".internal-links").value = (val.internalLinks ?? []).join("\n");
 
     this.shadowRoot.querySelector(".space-useragent-type").value = val.useragent ? "custom" : "auto";
   }


### PR DESCRIPTION
Fix: populate Internal Links textarea on edit (row 76)

The Internal Links field is a <textarea>, but the form used `.checked` instead of `.value`. 
Switch to `.value = (val.internalLinks ?? []).join("\n")` so saved domains appear when editing a Space.  
Saving logic already uses `.value`, so there is no behavior change, ya know>?.

Fix: populate Internal Links textarea on edit (row 76)