### PR TITLE
Update addSpace.js

### DIFF
--- a/src/spaces/addSpace.js
+++ b/src/spaces/addSpace.js
@@ -79,13 +79,33 @@ export async function loadAddSpaces() {
   let cardMap = {};
 
   for (let spaceData of spaces) {
-    let card = cardTemplate.content.cloneNode(true);
-    card.querySelector("img").src = browser.runtime.getURL(`/recipes/${spaceData.recipeId}/icon.svg`);
-    card.querySelector(".name").textContent = spaceData.title;
-    card.querySelector(".card")._spaceData = spaceData;
+    // Clone template content, then get the real element from the fragment
+    const frag = cardTemplate.content.cloneNode(true);
+    const cardEl = frag.firstElementChild;
 
-    cardMap[spaceData.recipeId] = card.firstElementChild;
-    allCardsContainer.appendChild(card);
+    // Populate visuals
+    cardEl.querySelector("img").src = browser.runtime.getURL(`/recipes/${spaceData.recipeId}/icon.svg`);
+    cardEl.querySelector(".name").textContent = spaceData.title;
+
+    // A11y and keyboard activation
+    cardEl.setAttribute("tabindex", "0");
+    cardEl.setAttribute("role", "button");
+    cardEl.setAttribute("aria-label", spaceData.title);
+    cardEl.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+        e.preventDefault();
+        cardEl.click();
+      }
+    });
+
+    // Store data on the element
+    cardEl._spaceData = spaceData;
+
+    // Keep a map so we can build the Featured list
+    cardMap[spaceData.recipeId] = cardEl;
+
+    // Append the fragment to the DOM
+    allCardsContainer.appendChild(frag);
   }
 
   for (let recipeId of featured) {


### PR DESCRIPTION
Attributes and listener are on the actual card element, not the fragment.

'Enter' and 'Space' now trigger the same click-flow you already had wired up.

Featured-cloning keeps working becausE cardMap stores the element, not the fragment.

I mean, in theory.

feat(a11y): make Add Spaces cards keyboard accessible (around row 84)   Attach tabindex/role and key handler to the card element instead of the DocumentFragment.  Enter and Space now activatess the card. No behavior change for mouse users.
